### PR TITLE
Add placeholder for staging jupyterhub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,19 @@ staging:
   only:
   - master
 
+# Training is run automatically as part of staging
+# Upgrades if already installed
+training:
+  stage: staging
+  script:
+    - sh gitlab-ci/deploy.sh
+    # TODO: Check we can run singleuser servers
+  environment:
+    name: staging-training
+    url: https://idr-analysis.openmicroscopy.org/training
+  only:
+  - master
+
 # Production requires a manual trigger
 approval:
   stage: approval

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -28,6 +28,25 @@ releases:
       - name: singleuser.extraEnv.IDR_PASSWORD
         value: "{{ env \"SECRET_IDR_PASSWORD\" }}"
 
+
+######################################################################
+# JupyterHub training
+# This is deployed as part of staging for now
+
+  - <<: *RELEASE_COMMON
+    name: jupyterhub-training
+    namespace: jupyterhub-training
+    labels:
+      deployment: staging
+      application: training
+    values:
+      - jupyterhub-config.yaml
+      - jupyterhub-training.yaml
+    set:
+      - name: proxy.secretToken
+        value: "{{ env \"SECRET_JUPYTERHUB_PROXY_TOKEN\" }}"
+
+
 ######################################################################
 # JupyterHub production
 

--- a/jupyterhub-training.yaml
+++ b/jupyterhub-training.yaml
@@ -1,0 +1,11 @@
+hub:
+  baseUrl: /training/
+
+singleuser:
+  image:
+    name: imagedata/jupyter-docker
+    tag: 0.8.1
+#    name: openmicroscopy/training-notebooks
+#    tag: 0.1.0
+
+# Use the same cpu memory and networkPolicy limits as staging


### PR DESCRIPTION
Adds idr-analysis.openmicroscopy.org/training

This is deployed automatically as part of the staging deployment (as soon as the `master` branch is updated) instead of after the manual `approval` stage since there isn't yet a separate staging-training.