### PR TITLE
Disable prepuller as it regularly fails and blocks the whole deployment

### DIFF
--- a/jupyterhub-config.yaml
+++ b/jupyterhub-config.yaml
@@ -63,7 +63,9 @@ singleuser:
 
 prePuller:
   hook:
-    enabled: true
+    # TODO: The prepuller fails intermittently, re-enable when we upgrade
+    # zero-to-jupyterhub
+    enabled: false
 
 ingress:
   enabled: true


### PR DESCRIPTION
Re-enable when zero-to-jupyterhub is upgraded