### PR TITLE
Add jupyterhub deployment for ITR VAE-0.5.1

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -48,6 +48,26 @@ releases:
 
 
 ######################################################################
+# JupyterHub ITR production
+
+  # Note this is newer than the version in RELEASE_COMMON
+  - chart: jupyterhub/jupyterhub
+    # Mon, 06 Aug 2018 06:36:53 +0000
+    version: v0.7-92ccb36
+    name: jupyterhub-itr-public
+    namespace: jupyterhub-itr-public
+    labels:
+      deployment: production
+      application: itr-public
+    values:
+      - jupyterhub-config.yaml
+      - jupyterhub-itr-public.yaml
+    set:
+      - name: proxy.secretToken
+        value: "{{ env \"SECRET_JUPYTERHUB_PROXY_TOKEN\" }}"
+
+
+######################################################################
 # JupyterHub production
 
   - <<: *RELEASE_COMMON

--- a/jupyterhub-itr-public.yaml
+++ b/jupyterhub-itr-public.yaml
@@ -1,0 +1,35 @@
+hub:
+  baseUrl: /itr-public/
+
+singleuser:
+  image:
+    name: imagedata/idr-notebooks
+    tag: VAE-0.5.1
+  # Increase resources since some notebooks are resource intensive
+  cpu:
+    limit: 2
+    guarantee: 0.1
+  memory:
+    limit: 2G
+    guarantee: 512M
+  networkPolicy:
+    enabled: true
+    # Block all except:
+    # - internal DNS
+    # - EMBL-EBI and University of Dundee
+    egress:
+      - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+        ports:
+        # BUG: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/824
+        # Temporary workaround: allow egress to port 8081 on internal IPs
+        - port: 8081
+        - port: 53
+          protocol: UDP
+      - to:
+        - ipBlock:
+            cidr: 193.60.0.0/14
+        - ipBlock:
+            cidr: 134.36.0.0/16
+  cmd: jupyterhub-singleuser


### PR DESCRIPTION
A new prefix `/itr-public` for public ITR notebooks. This currently uses a newer version of zero-to-jupyterhub than the other deployments. Assuming all goes well the rest will up be updated later.