### PR TITLE
Remove all {{ overrides }} in helmfile.yaml

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -31,9 +31,6 @@ releases:
       application: staging
     values:
       - values/jupyterhub-config.yaml
-    {{ range .Environment.Values.jupyterhub_staging_overrides }}
-      - {{ . }}
-    {{ end }}
     set:
       - name: proxy.secretToken
         value: {{ requiredEnv "SECRET_JUPYTERHUB_PROXY_TOKEN" }}
@@ -55,9 +52,6 @@ releases:
     values:
       - values/jupyterhub-config.yaml
       - values/jupyterhub-training.yaml
-    {{ range .Environment.Values.jupyterhub_training_overrides }}
-      - {{ . }}
-    {{ end }}
     set:
       - name: proxy.secretToken
         value: {{ requiredEnv "SECRET_JUPYTERHUB_PROXY_TOKEN" }}
@@ -77,9 +71,6 @@ releases:
     values:
       - values/jupyterhub-config.yaml
       - values/jupyterhub-itr-public.yaml
-    {{ range .Environment.Values.jupyterhub_itr_overrides }}
-      - {{ . }}
-    {{ end }}
     set:
       - name: proxy.secretToken
         value: {{ requiredEnv "SECRET_JUPYTERHUB_PROXY_TOKEN" }}
@@ -101,9 +92,6 @@ releases:
     values:
       - values/jupyterhub-config.yaml
       - values/jupyterhub-public.yaml
-    {{ range .Environment.Values.jupyterhub_public_overrides }}
-      - {{ . }}
-    {{ end }}
     set:
       - name: proxy.secretToken
         value: {{ requiredEnv "SECRET_JUPYTERHUB_PROXY_TOKEN" }}
@@ -121,9 +109,6 @@ releases:
     values:
       - values/jupyterhub-config.yaml
       - values/jupyterhub-vae.yaml
-    {{ range .Environment.Values.jupyterhub_vae_overrides }}
-      - {{ . }}
-    {{ end }}
     set:
       - name: proxy.secretToken
         value: {{ requiredEnv "SECRET_JUPYTERHUB_PROXY_TOKEN" }}
@@ -141,9 +126,6 @@ releases:
       deployment: production
       application: vae
     values:
-    {{ range .Environment.Values.jupyterhub_vae_shared_storage_overrides }}
-      - {{ . }}
-    {{ end }}
 
   - name: jupyterhub-vae-aai
     chart: jupyterhub/jupyterhub
@@ -178,9 +160,6 @@ releases:
       deployment: production
       application: website
     values:
-    {{ range .Environment.Values.idr_analysis_website_overrides }}
-      - {{ . }}
-    {{ end }}
 
 
 ######################################################################
@@ -208,9 +187,6 @@ releases:
       application: monitoring
     values:
       - values/prometheus.yaml
-    {{ range .Environment.Values.prometheus_overrides }}
-      - {{ . }}
-    {{ end }}
 
   - name: grafana
     namespace: monitoring
@@ -221,9 +197,6 @@ releases:
       application: monitoring
     values:
       - values/grafana.yaml
-    {{ range .Environment.Values.grafana_overrides }}
-      - {{ . }}
-    {{ end }}
     set:
       - name: env.GF_AUTH_GITHUB_CLIENT_ID
         value: {{ requiredEnv "SECRET_GRAFANA_GITHUB_CLIENTID" }}
@@ -232,12 +205,3 @@ releases:
 
     # To get the auto-generated Grafana admin password:
     # kubectl get secret --namespace monitoring grafana -o jsonpath="{.data.admin-password}" | base64 -d ; echo
-
-
-environments:
-  default:
-    values:
-      - production.yaml
-  minikube:
-    values:
-      - minikube.yaml


### PR DESCRIPTION
Remove the the environment overrides added in #18.

It worked when tested locally but failed in the GitLab deploy: https://gitlab.com/openmicroscopy/mirrors/k8s-analysis-deploy/-/jobs/153459979

```
error during helmfile.yaml parsing: template: stringTemplate:34:25: executing "stringTemplate" at <.Environment.Values....>: map has no entry for key "jupyterhub_staging_overrides"
```