### PR TITLE
update training notebooks

### DIFF
--- a/values/jupyterhub-training.yaml
+++ b/values/jupyterhub-training.yaml
@@ -4,7 +4,7 @@ hub:
 singleuser:
   image:
     name: openmicroscopy/training-notebooks
-    tag: 0.5.0
+    tag: 0.5.1
   # Increase resources since some training notebooks are resources intensive
   cpu:
     limit: 2


### PR DESCRIPTION
bump version to 0.5.1

available at https://cloud.docker.com/u/openmicroscopy/repository/docker/openmicroscopy/training-notebooks/general

cc @manics 