### PR TITLE
training 0.6.0

### DIFF
--- a/values/jupyterhub-training.yaml
+++ b/values/jupyterhub-training.yaml
@@ -4,7 +4,7 @@ hub:
 singleuser:
   image:
     name: openmicroscopy/training-notebooks
-    tag: 0.5.1
+    tag: 0.6.0
   # Increase resources since some training notebooks are resources intensive
   cpu:
     limit: 2


### PR DESCRIPTION
use 0.6.0
See https://cloud.docker.com/u/openmicroscopy/repository/registry-1.docker.io/openmicroscopy/training-notebooks/tags

cc @manics 