### PR TITLE
jupyterlab

### DIFF
--- a/values/jupyterhub-config.yaml
+++ b/values/jupyterhub-config.yaml
@@ -59,7 +59,7 @@ singleuser:
   extraEnv:
     IDR_HOST: idr.openmicroscopy.org
     IDR_USER: public
-  cmd: jupyter-labhub
+    JUPYTER_ENABLE_LAB: true
 
 prePuller:
   hook:


### PR DESCRIPTION
 use env variable instead of command
Using the command implies that ``xvfb-run`` was not executed
leading to a failure when running the Fiji notebook
cc @pwalczysko @manics 