### PR TITLE
bump to 0.7.1

### DIFF
--- a/values/jupyterhub-training.yaml
+++ b/values/jupyterhub-training.yaml
@@ -4,7 +4,7 @@ hub:
 singleuser:
   image:
     name: openmicroscopy/training-notebooks
-    tag: 0.7.0
+    tag: 0.7.1
   # Increase resources since some training notebooks are resources intensive
   cpu:
     limit: 2


### PR DESCRIPTION
Image available on https://hub.docker.com/repository/docker/openmicroscopy/training-notebooks